### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   workflow_dispatch:  # manuel tetikleme için
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mstfknn/phishing-fasttext-model/security/code-scanning/1](https://github.com/mstfknn/phishing-fasttext-model/security/code-scanning/1)

The best practice fix is to add a `permissions` block at either the workflow or job level, explicitly limiting permissions of the GitHub Actions workflow's `GITHUB_TOKEN`. Since the primary need in this workflow is to checkout repository contents (`actions/checkout`), the minimal required permission is `contents: read`. None of the steps appear to require write access to issues, pull requests, or packages in GitHub itself. The most maintainable design is to place the permissions block at the workflow level (after the `on:` section), applying it to all jobs unless overridden.

**Files/regions/lines to change:**  
- File: `.github/workflows/docker-publish.yml`
- Insert the permissions block at the top level, just after the `on:` section (i.e., after line 7)

**What is needed:**  
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
- No new methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
